### PR TITLE
Fix uninitialized memory accesses

### DIFF
--- a/include/casc/SimplicialComplex.h
+++ b/include/casc/SimplicialComplex.h
@@ -1143,6 +1143,7 @@ class simplicial_complex
             : node_count(0)
         {
             // Create a root node
+            level_count[0] = 0;  // avoid incrementing uninitialized memory
             _root = create_node<0>();
             for (auto &x : level_count) // Initialize level_count to 0 for all
                                         // levels

--- a/include/casc/SimplicialComplex.h
+++ b/include/casc/SimplicialComplex.h
@@ -1317,6 +1317,10 @@ class simplicial_complex
             {
                 s[i++] = curr.first;
             }
+            while (i < n)
+            {
+                s[i++] = KeyType();
+            }
 
             return s;
         }


### PR DESCRIPTION
Each commit fixes a warning on GCC 11.2.1 with `-Wmaybe-uninitialized`.